### PR TITLE
Support netmask for VPN CIDR allocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Cleans up all the created veth interfaces and undoes all the system changes.
 #### Configurable
 
 Can handle `dnsmasq.conf` with variables. SRVIPSUBNET (default: 10.0.0) can be set through environment variables to configure the server at startup.
+Can handle `dnsmasq.conf` with variables. SRVIPNETMASK (default: 255.255.255.0) can be set through environment variables to configure the server at startup.
 
 ```bash
 ### Example and default configuration
@@ -48,7 +49,7 @@ port=0
 interface=tap_soft
 dhcp-option=3
 dhcp-option=6
-dhcp-range=tap_soft,$SRVIPSUBNET.129,$SRVIPSUBNET.199,255.255.255.0,12h
+dhcp-range=tap_soft,$SRVIPSUBNET.129,$SRVIPSUBNET.199,$SRVIPNETMASK,12h
 ```
 
 #### Up-to-Date
@@ -114,7 +115,7 @@ cp vpn_server.config ./cfg/vpn_server.config # Has a default
 
 ```
 interface=tap_soft
-dhcp-range=tap_soft,$SRVIPSUBNET.129,$SRVIPSUBNET.199,255.255.255.0,12h
+dhcp-range=tap_soft,$SRVIPSUBNET.129,$SRVIPSUBNET.199,$SRVIPNETMASK,12h
 ```
 
 ### Deploy via Docker
@@ -124,6 +125,7 @@ docker create \
   --name=softether-vpnsrv \
   -e TZ=Europe/Vienna \
   -e SRVIPSUBNET=10.0.0 \
+  -e SRVIPNETMASK=255.255.255.0 \
   -p 1443:1443/tcp \
   -p 992:992/tcp \
   -p 5555:5555/tcp \
@@ -145,6 +147,8 @@ docker create \
 TZ=
 # VPN Server IP Subnet in form of xx.xx.xx (default: 10.0.0), it can also can rewrite dnsmasq.conf with SED if \$SRVIPSUBNET inside dnsmasq.conf is set."
 SRVIPSUBNET=
+# VPN Server IP Subnet Netmask in form of xx.xx.xx.xx (default: 255.255.255.0), it can also can rewrite dnsmasq.conf with SED if \$SRVIPNETMASK inside dnsmasq.conf is set."
+SRVIPNETMASK=
 # Sleep Time for Server Alive Check in Seconds (default: 600)
 SLEEPTIME=
 # Keep logs or delete them in between sleeptime. To keep set the type to 1.

--- a/build/cont-init.d/10-routing.sh
+++ b/build/cont-init.d/10-routing.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 
 # Create IP tables rules
+function convMask () {
+  c=0 x=0$( printf '%o' ${1//./ } )
+  while [ $x -gt 0 ]; do
+      let c+=$((x%2)) 'x>>=1'
+  done
+  echo "$c";
+}
 echo "Creating postrouting rules."
-iptables -t nat -A POSTROUTING -s ${SRVIPSUBNET:-10.0.0}.0/24 -j MASQUERADE
+cidrNet=$(convMask ${SRVIPNETMASK:-255.255.255.0})
+iptables -t nat -A POSTROUTING -s ${SRVIPSUBNET:-10.0.0}.0/${cidrNet:-24} -j MASQUERADE

--- a/build/cont-init.d/20-dhcp-conf.sh
+++ b/build/cont-init.d/20-dhcp-conf.sh
@@ -6,4 +6,4 @@ if [ ! -f /cfg/dnsmasq.conf ]; then
   cp /etc/dnsmasq.conf.default /cfg/dnsmasq.conf
 fi
 
-sed "s/\$SRVIPSUBNET/${SRVIPSUBNET:-10.0.0}/g" /cfg/dnsmasq.conf >/etc/dnsmasq.conf
+sed -e "s/\$SRVIPSUBNET/${SRVIPSUBNET:-10.0.0}/g" -e "s/\$SRVIPNETMASK/${SRVIPNETMASK:-255.255.255.0}/g" /cfg/dnsmasq.conf >/etc/dnsmasq.conf

--- a/build/dnsmasq.conf
+++ b/build/dnsmasq.conf
@@ -1,5 +1,5 @@
 port=0
 interface=tap_soft
-dhcp-range=tap_soft,$SRVIPSUBNET.10,$SRVIPSUBNET.255,255.255.255.0,12h
+dhcp-range=tap_soft,$SRVIPSUBNET.10,$SRVIPSUBNET.255,$SRVIPNETMASK,12h
 dhcp-option=tap_soft,3,$SRVIPSUBNET.1
 dhcp-option=tap_soft,6,8.8.8.8,8.8.4.4

--- a/build/services.d/softether-vpnsrv/run
+++ b/build/services.d/softether-vpnsrv/run
@@ -14,8 +14,7 @@ echo "Waiting 3 seconds."
 s6-sleep 3
 echo "Binded IP address to the server with ${SRVIPSUBNET:-10.0.0}.1"
 ip tuntap add dev tap_soft mode tap
-/sbin/ifconfig tap_soft ${SRVIPSUBNET:-10.0.0}.1
-
+/sbin/ifconfig tap_soft ${SRVIPSUBNET:-10.0.0}.1 netmask ${SRVIPNETMASK:-255.255.255.0}
 # Check health
 while ping -c 1 -W 10 "${SRVIPSUBNET:-10.0.0}.1" >&/dev/null && pgrep dnsmasq >&/dev/null; do
   echo "-------------------------------"

--- a/init-env.sh
+++ b/init-env.sh
@@ -9,6 +9,8 @@ ENVFILECONTENTS=(
   "TZ="
   "# VPN Server IP Subnet in form of xx.xx.xx (default: 10.0.0), it can also rewrite dnsmasq.conf with SED if \$SRVIPSUBNET inside dnsmasq.conf is set."
   "SRVIPSUBNET="
+  "# VPN Server IP Subnet Netmask in form of xx.xx.xx.xx (default: 255.255.255.0) \$SRVIPNETMASK"
+  "SRVIPNETMASK="
   "# Sleep Time for Server Alive Check in Seconds (default: 600)"
   "SLEEPTIME="
   "# Keep logs or delete them in between sleeptime. To keep set the type to 1."


### PR DESCRIPTION
**fix for issue #9**
* Allow defining a SRVIPNETMASK that will be used in all applicable configurations including the previously omitted `ifconfig tap_soft` in `build/services.d/softether-vpnsrv/run` script. This addresses issue #9
* Updated 10-routing.sh to set the CIDR subnet using a function to convert the supplied xx.xx.xx.xx netmask.
* Updated 20-dhcp-conf.sh  to additionally replace SRVIPNETMASK defaulting to 255.255.255.0 which was the original default hard coded value.
* Updated README.md and init-env.sh to specify the added SRVIPNETMASK value.